### PR TITLE
Removed @python_2_unicode_compatible decorator

### DIFF
--- a/django_rest_passwordreset/models.py
+++ b/django_rest_passwordreset/models.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth import get_user_model
 
@@ -24,7 +23,6 @@ __all__ = [
 ]
 
 
-@python_2_unicode_compatible
 class ResetPasswordToken(models.Model):
     class Meta:
         verbose_name = _("Password Reset Token")


### PR DESCRIPTION
@python_2_unicode_compatible is no longer present in Django 3.  This decorator needs to be removed so that the package will run under Django 3