### PR TITLE
Fix wrong __all__ in views

### DIFF
--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -17,7 +17,7 @@ from django_rest_passwordreset.signals import reset_password_token_created, pre_
 User = get_user_model()
 
 __all__ = [
-    'ValidateToken',
+    'ResetPasswordValidateToken',
     'ResetPasswordConfirm',
     'ResetPasswordRequestToken',
     'reset_password_validate_token',
@@ -58,7 +58,7 @@ class ResetPasswordValidateToken(GenericAPIView):
             # delete expired token
             reset_password_token.delete()
             return Response({'status': 'expired'}, status=status.HTTP_404_NOT_FOUND)
-        
+
         return Response({'status': 'OK'})
 
 


### PR DESCRIPTION
The class in `views.__all__` was `ValidateToken`, it should be `ResetPasswordValidateToken` to match