### PR TITLE
Add ability to create registration token

### DIFF
--- a/django_rest_passwordreset/models.py
+++ b/django_rest_passwordreset/models.py
@@ -122,7 +122,7 @@ def eligible_for_reset(self, register_token=False):
     
     # if we are checking for the register_token, the user cannot have a usable password.
     if register_token:
-        return not self.has_usable_password
+        return not self.has_usable_password()
 
     if getattr(settings, 'DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD', True):
         # if we require a usable password then return the result of has_usable_password()

--- a/django_rest_passwordreset/register.py
+++ b/django_rest_passwordreset/register.py
@@ -5,7 +5,7 @@ from django_rest_passwordreset.signals import reset_password_token_created
 
 User = get_user_model()
 
-def create_registration_token(user):
+def create_registration_token(user_id):
     """
     A function which creasts a Registration Token for a new User
 
@@ -13,7 +13,7 @@ def create_registration_token(user):
     """
 
     # find a user by pk
-    user = User.objects.get(pk=user)
+    user = User.objects.get(pk=user_id)
 
     if user.eligible_for_reset(register_token=True):
         #clear the user's tokens

--- a/django_rest_passwordreset/register.py
+++ b/django_rest_passwordreset/register.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.contrib.auth.password_validation import validate_password, get_password_validators
+from django.utils.translation import ugettext_lazy as _
+from django.utils import timezone
+from django.conf import settings
+from rest_framework import status, serializers, exceptions
+from rest_framework.generics import GenericAPIView
+from rest_framework.response import Response
+
+from django_rest_passwordreset.serializers import EmailSerializer, PasswordTokenSerializer, TokenSerializer
+from django_rest_passwordreset.models import ResetPasswordToken, clear_expired, get_password_reset_token_expiry_time, \
+    get_password_reset_lookup_field, clear_user_tokens
+from django_rest_passwordreset.signals import reset_password_token_created, pre_password_reset, post_password_reset
+
+User = get_user_model()
+
+
+def create_registration_token(self, user):
+    """
+    A function which creasts a Registration Token for a new User
+
+    User's must not have a useable password
+    """
+
+    # find a user by pk
+    user = User.objects.get(pk=user)
+    
+    if user.eligible_for_reset(register_token=True):
+        #clear the user's tokens
+        clear_user_tokens(user)
+
+        # create a new token 
+        token = ResetPasswordToken.objects.create(
+            user=user,
+        )
+        # send a signal that the password token was created
+        # let whoever receives this signal handle sending the email for the password reset
+        reset_password_token_created.send(sender=self, instance=self, reset_password_token=token)
+    else:
+        raise Exception("User not eligible for reset.")

--- a/django_rest_passwordreset/register.py
+++ b/django_rest_passwordreset/register.py
@@ -5,7 +5,7 @@ from django_rest_passwordreset.signals import reset_password_token_created
 
 User = get_user_model()
 
-def create_registration_token(self, user):
+def create_registration_token(user):
     """
     A function which creasts a Registration Token for a new User
 
@@ -25,6 +25,6 @@ def create_registration_token(self, user):
         )
         # send a signal that the password token was created
         # let whoever receives this signal handle sending the email for the password reset
-        reset_password_token_created.send(sender=self, instance=self, reset_password_token=token)
+        reset_password_token_created.send(sender=None, instance=None, reset_password_token=token)
     else:
         raise Exception("User not eligible for reset.")

--- a/django_rest_passwordreset/register.py
+++ b/django_rest_passwordreset/register.py
@@ -1,21 +1,9 @@
-from datetime import timedelta
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
-from django.contrib.auth.password_validation import validate_password, get_password_validators
-from django.utils.translation import ugettext_lazy as _
-from django.utils import timezone
-from django.conf import settings
-from rest_framework import status, serializers, exceptions
-from rest_framework.generics import GenericAPIView
-from rest_framework.response import Response
+from django_rest_passwordreset.models import ResetPasswordToken, clear_user_tokens
+from django_rest_passwordreset.signals import reset_password_token_created
 
-from django_rest_passwordreset.serializers import EmailSerializer, PasswordTokenSerializer, TokenSerializer
-from django_rest_passwordreset.models import ResetPasswordToken, clear_expired, get_password_reset_token_expiry_time, \
-    get_password_reset_lookup_field, clear_user_tokens
-from django_rest_passwordreset.signals import reset_password_token_created, pre_password_reset, post_password_reset
 
 User = get_user_model()
-
 
 def create_registration_token(self, user):
     """
@@ -26,7 +14,7 @@ def create_registration_token(self, user):
 
     # find a user by pk
     user = User.objects.get(pk=user)
-    
+
     if user.eligible_for_reset(register_token=True):
         #clear the user's tokens
         clear_user_tokens(user)

--- a/django_rest_passwordreset/serializers.py
+++ b/django_rest_passwordreset/serializers.py
@@ -16,6 +16,7 @@ class EmailSerializer(serializers.Serializer):
 class PasswordTokenSerializer(serializers.Serializer):
     password = serializers.CharField(label=_("Password"), style={'input_type': 'password'})
     token = serializers.CharField()
+    register = serializers.BooleanField()
 
 
 class TokenSerializer(serializers.Serializer):

--- a/django_rest_passwordreset/serializers.py
+++ b/django_rest_passwordreset/serializers.py
@@ -21,3 +21,4 @@ class PasswordTokenSerializer(serializers.Serializer):
 
 class TokenSerializer(serializers.Serializer):
     token = serializers.CharField()
+    register = serializers.BooleanField()

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -116,16 +116,20 @@ class ResetPasswordConfirm(GenericAPIView):
             reset_password_token.user.save()
             post_password_reset.send(sender=self.__class__, user=reset_password_token.user)
 
-        # Log the user in
-        refresh = RefreshToken.for_user(reset_password_token.user)
+            # Log the user in
+            refresh = RefreshToken.for_user(reset_password_token.user)
 
-        # Delete all password reset tokens for this user
-        ResetPasswordToken.objects.filter(user=reset_password_token.user).delete()
+            # Delete all password reset tokens for this user
+            ResetPasswordToken.objects.filter(user=reset_password_token.user).delete()
 
-        return Response({
-            'refresh': str(refresh),
-            'access': str(refresh.access_token),
-        })
+            return Response({
+                'refresh': str(refresh),
+                'access': str(refresh.access_token),
+            })
+        
+        else:
+            #User is ineligible for password reset
+            return Response({'status': 'User ineligible for password reset'}, status=status.HTTP_403_FORBIDDEN)
 
 
 class ResetPasswordRequestToken(GenericAPIView):

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -95,7 +95,7 @@ class ResetPasswordConfirm(GenericAPIView):
             return Response({'status': 'expired'}, status=status.HTTP_404_NOT_FOUND)
 
         # change users password (if we got to this code it means that the user is_active)
-        if reset_password_token.user.eligible_for_reset():
+        if reset_password_token.user.eligible_for_reset(register=register):
             pre_password_reset.send(sender=self.__class__, user=reset_password_token.user)
             try:
                 # validate the password against existing validators

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -75,9 +75,10 @@ class ResetPasswordConfirm(GenericAPIView):
         serializer.is_valid(raise_exception=True)
         password = serializer.validated_data['password']
         token = serializer.validated_data['token']
+        register = serializer.validated_data['register']
 
         # get token validation time
-        password_reset_token_validation_time = get_password_reset_token_expiry_time()
+        password_reset_token_validation_time = get_password_reset_token_expiry_time(register_token=register)
 
         # find token
         reset_password_token = ResetPasswordToken.objects.filter(key=token).first()

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -95,7 +95,7 @@ class ResetPasswordConfirm(GenericAPIView):
             return Response({'status': 'expired'}, status=status.HTTP_404_NOT_FOUND)
 
         # change users password (if we got to this code it means that the user is_active)
-        if reset_password_token.user.eligible_for_reset(register=register):
+        if reset_password_token.user.eligible_for_reset(register_token=register):
             pre_password_reset.send(sender=self.__class__, user=reset_password_token.user)
             try:
                 # validate the password against existing validators

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -41,9 +41,10 @@ class ResetPasswordValidateToken(GenericAPIView):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
         token = serializer.validated_data['token']
+        register = serializer.validated_data['register']
 
         # get token validation time
-        password_reset_token_validation_time = get_password_reset_token_expiry_time()
+        password_reset_token_validation_time = get_password_reset_token_expiry_time(register_token=register)
 
         # find token
         reset_password_token = ResetPasswordToken.objects.filter(key=token).first()


### PR DESCRIPTION
### Problem

The methodology in this library also works great for creating registration tokens. These are useful in the case where a user cannot signup themselves, but need an account created for them, and then are notified to sign up and create a password. This would be applicable in most business facing team apps. 

### Solution

- Add function `create_registration_token(user)` that creates a registration token for a user where `.has_usable_password()` is False. If any other tokens exist for the targeted user, delete them. 

- Update `get_password_reset_token_expiry_time` to change the expiry time based on if the token being queried is a reset token or a registration token.

- Require boolean variable `register` to be passed in the /reset_password/confirm/ request. If True, we are verifying a registration token, if False, we are verifying a reset token.

### Referenced / Requested
Mentioned that this functionality could be helpful in #52 by @anx-ckreuzberger. (This PR does not address the issue itself, but the comment)

> I don't think that this is a use-case that should be implemented within django-rest-passwordreset.
> 
> Re-enabling tokens is also sub-optimal, I would recommend to change the expiry time based on token type (e.g., you could have two token types, one for `registration` and one for `password_reset`).
> 
> As I'm time-constraint on supporting this library I would like to keep the footprint as small as possible, and not introduce new features.
> 
> I'll keep this issue open for others to comment on this, and maybe someone will create a fork that supports this behaviour.
