### PR TITLE
Updated documentation on endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ INSTALLED_APPS = (
 python manage.py migrate
 ```
 
-4. This package provides two endpoints, which can be included by including ``django_rest_passwordreset.urls`` in your ``urls.py`` as follows:
+4. This package provides three endpoints, which can be included by including ``django_rest_passwordreset.urls`` in your ``urls.py`` as follows:
 ```python
 from django.conf.urls import url, include
 
@@ -48,7 +48,7 @@ urlpatterns = [
     ...
     url(r'^api/password_reset/', include('django_rest_passwordreset.urls', namespace='password_reset')),
     ...
-]    
+]
 ```
 **Note**: You can adapt the url to your needs.
 
@@ -56,11 +56,11 @@ urlpatterns = [
 
 The following endpoints are provided:
 
- * `POST ${API_URL}/reset_password/` - request a reset password token by using the ``email`` parameter
- * `POST ${API_URL}/reset_password/confirm/` - using a valid ``token``, the users password is set to the provided ``password``
- * `POST ${API_URL}/reset_password/validate_token/` - will return a 200 if a given ``token`` is valid
+ * `POST ${PASSWORD_RESET_URL}/` - request a reset password token by using the ``email`` parameter
+ * `POST ${PASSWORD_RESET_URL}/confirm/` - using a valid ``token``, the users password is set to the provided ``password``
+ * `POST ${PASSWORD_RESET_URL}/validate_token/` - will return a 200 if a given ``token`` is valid
  
-where `${API_URL}/` is the url specified in your *urls.py* (e.g., `api/password_reset/`)
+where `${PASSWORD_RESET_URL}/` is the url specified in your *urls.py* (e.g., `api/password_reset/` as in the example above)
  
 ### Signals
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ urlpatterns = [
 
 The following endpoints are provided:
 
- * `POST ${PASSWORD_RESET_URL}/` - request a reset password token by using the ``email`` parameter
- * `POST ${PASSWORD_RESET_URL}/confirm/` - using a valid ``token``, the users password is set to the provided ``password``
- * `POST ${PASSWORD_RESET_URL}/validate_token/` - will return a 200 if a given ``token`` is valid
+ * `POST ${API_URL}/reset_password/` - request a reset password token by using the ``email`` parameter
+ * `POST ${API_URL}/reset_password/confirm/` - using a valid ``token``, the users password is set to the provided ``password``
+ * `POST ${API_URL}/reset_password/validate_token/` - will return a 200 if a given ``token`` is valid
  
-where `${PASSWORD_RESET_URL}/` is the url specified in your *urls.py* (e.g., `api/password_reset/` as in the example above)
+where `${API_URL}/` is the url specified in your *urls.py* (e.g., `api/` as in the example above)
  
 ### Signals
 


### PR DESCRIPTION
Corrected the description of section **Endpoints** by removing the redundant `reset_password` prefix from example URLs.