### PR TITLE
Added workflow to publish package on PyPi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish package
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+        architecture: 'x64'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build source and binary distribution package
+      run: |
+        python setup.py sdist bdist_wheel
+      env:
+        PACKAGE_VERSION: ${{ github.ref }}
+
+    - name: Check distribution package
+      run: |
+        twine check dist/*
+
+    - name: Publish distribution package
+      run: |
+        twine upload dist/*
+      env:
+        TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_NON_INTERACTIVE: yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: Run linter and tests
 on: [push, pull_request]
 
 jobs:
@@ -79,4 +79,3 @@ jobs:
       run: |
         cd tests
         python manage.py test
-

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-rest-passwordreset',
-    version='1.2',
+    version=os.getenv('PACKAGE_VERSION', '0.0.0').replace('refs/tags/', ''),
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Added GitHub Action Workflow to publish the package on PyPi. The action triggers when a release is drafted on GitHub and uses the GitHub release version as the package version.

The action expects secrets to be configured as follows:
* `PYPI_REPOSITORY`: Either pypi or testpypi.
* `PYPI_USERNAME`: The username (not your name nor your email) at PyPi (or at PyPi Testing).
* `PYPI_PASSWORD`: The password at PyPi (or at PyPi Testing).