### PR TITLE
Extend test workflow for django 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,21 +12,25 @@ jobs:
           - "3.6"
           - "3.7"
           - "3.8"
+          - "3.9"
         django-version:
           - "2.2"
-          - "3.0"
           - "3.1"
+          - "3.2"
         drf-version:
           - "3.10"
           - "3.11"
+          - "3.12"
         exclude:
           - python-version: "3.5"
-            django-version: "3.0"
-          - python-version: "3.5"
             django-version: "3.1"
+          - python-version: "3.5"
+            django-version: "3.2"
           # DRF 3.10 imports FieldDoesNotExist from django.db.models,
           # which has been moved to django.core.exceptions as of Django 3.1
           - django-version: "3.1"
+            drf-version: "3.10"
+          - django-version: "3.2"
             drf-version: "3.10"
 
     steps:


### PR DESCRIPTION
Enables tests to run against Django 3.2 and DRF 3.12