### PR TITLE
Making the README.md a little more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ urlpatterns = [
 
 The following endpoints are provided:
 
- * `POST ${API_URL}/reset_password/` - request a reset password token by using the ``email`` parameter
- * `POST ${API_URL}/reset_password/confirm/` - using a valid ``token``, the users password is set to the provided ``password``
- * `POST ${API_URL}/reset_password/validate_token/` - will return a 200 if a given ``token`` is valid
+ * `POST ${API_URL}/` - request a reset password token by using the ``email`` parameter
+ * `POST ${API_URL}/confirm/` - using a valid ``token``, the users password is set to the provided ``password``
+ * `POST ${API_URL}/validate_token/` - will return a 200 if a given ``token`` is valid
  
-where `${API_URL}/` is the url specified in your *urls.py* (e.g., `api/` as in the example above)
+where `${API_URL}/` is the url specified in your *urls.py* (e.g., `api/password_reset` as in the example above)
  
 ### Signals
 


### PR DESCRIPTION
Hi, I noticed you say the provided urls are reset_password/, /reset_password/confirm/ and /reset_password/validate_token but I believe the reset_password bit is not necessary and can be a little confusing, so tried to clean up a little bit the README