### PR TITLE
Allow password reset without being authenticated

### DIFF
--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -41,6 +41,7 @@ class ResetPasswordValidateToken(GenericAPIView):
     throttle_classes = ()
     permission_classes = ()
     serializer_class = ResetTokenSerializer
+    authentication_classes = ()
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)
@@ -55,6 +56,7 @@ class ResetPasswordConfirm(GenericAPIView):
     throttle_classes = ()
     permission_classes = ()
     serializer_class = PasswordTokenSerializer
+    authentication_classes = ()
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)
@@ -100,6 +102,7 @@ class ResetPasswordRequestToken(GenericAPIView):
     throttle_classes = ()
     permission_classes = ()
     serializer_class = EmailSerializer
+    authentication_classes = ()
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)


### PR DESCRIPTION
## Problem
Only authenticated users can request a password reset, as described here: https://github.com/anexia-it/django-rest-passwordreset/issues/67

## Solution
Adding `authentication_classes` to views.

