### PR TITLE
issue154: add reset_password_token to pre/post reset signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/project/django-rest-passwordreset/).
 
+## [Unreleased]
+
+- `pre_password_reset` and `post_password_reset` signals now provide `reset_password_token
+- Updated README test instructions
+
 ## [1.3.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ where `${API_URL}/` is the url specified in your *urls.py* (e.g., `api/password_
 ### Signals
 
 * ``reset_password_token_created(sender, instance, reset_password_token)`` Fired when a reset password token is generated
-* ``pre_password_reset(sender, user)`` - fired just before a password is being reset
-* ``post_password_reset(sender, user)`` - fired after a password has been reset
+* ``pre_password_reset(sender, user, reset_password_token)`` - fired just before a password is being reset
+* ``post_password_reset(sender, user, reset_password_token)`` - fired after a password has been reset
 
 ### Example for sending an e-mail
 
@@ -382,11 +382,19 @@ This library tries to follow the unix philosophy of "do one thing and do it well
 See folder [tests/](tests/). Basically, all endpoints are covered with multiple
 unit tests.
 
-Use this code snippet to run tests:
+Follow below instructions to run the tests.
+You may exchange the installed Django and DRF versions according to your requirements. 
+:warning: Depending on your local environment settings you might need to explicitly call `python3` instead of `python`.
 ```bash
-python setup.py install
-cd tests
-python manage.py test
+# install dependencies
+python -m pip install --upgrade pip
+pip install -r tests/requirements.txt
+
+# setup environment
+pip install -e .
+
+# run tests
+cd tests && python manage.py test
 ```
 
 ## Release on PyPi

--- a/django_rest_passwordreset/signals.py
+++ b/django_rest_passwordreset/signals.py
@@ -12,11 +12,11 @@ Signal arguments: instance, reset_password_token
 reset_password_token_created = Signal()
 
 """
-Signal arguments: user
+Signal arguments: user, reset_password_token
 """
 pre_password_reset = Signal()
 
 """
-Signal arguments: user
+Signal arguments: user, reset_password_token
 """
 post_password_reset = Signal()

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -82,7 +82,11 @@ class ResetPasswordConfirm(GenericAPIView):
 
         # change users password (if we got to this code it means that the user is_active)
         if reset_password_token.user.eligible_for_reset():
-            pre_password_reset.send(sender=self.__class__, user=reset_password_token.user)
+            pre_password_reset.send(
+                sender=self.__class__,
+                user=reset_password_token.user,
+                reset_password_token=reset_password_token,
+            )
             try:
                 # validate the password against existing validators
                 validate_password(
@@ -98,7 +102,11 @@ class ResetPasswordConfirm(GenericAPIView):
 
             reset_password_token.user.set_password(password)
             reset_password_token.user.save()
-            post_password_reset.send(sender=self.__class__, user=reset_password_token.user)
+            post_password_reset.send(
+                sender=self.__class__,
+                user=reset_password_token.user,
+                reset_password_token=reset_password_token,
+            )
 
         # Delete all password reset tokens for this user
         ResetPasswordToken.objects.filter(user=reset_password_token.user).delete()

--- a/tests/test/test_auth_test_case.py
+++ b/tests/test/test_auth_test_case.py
@@ -321,7 +321,11 @@ class AuthTestCase(APITestCase, HelperMixin):
 
         # now the other two signals should have been called
         self.assertTrue(mock_post_password_reset.called)
+        self.assertIn('reset_password_token', mock_post_password_reset.call_args[1])
+        self.assertEqual(mock_post_password_reset.call_args[1]['reset_password_token'], token1)
         self.assertTrue(mock_pre_password_reset.called)
+        self.assertIn('reset_password_token', mock_pre_password_reset.call_args[1])
+        self.assertEqual(mock_pre_password_reset.call_args[1]['reset_password_token'], token1)
 
     @override_settings(DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE=True)
     def test_try_reset_password_email_does_not_exist_no_leakage_enabled(self):


### PR DESCRIPTION
* `pre_password_reset` and `post_password_reset` signals now provide `reset_password_token`
* updated README test instructions

closes #154  