### PR TITLE
Fix the reset_password_token_created signal to be fired even when no token have been created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 
 ## [Unreleased]
 
+### Fixed
+- Fix the reset_password_token_created signal to be fired even when no token have been created. (#188)
+
 ## [1.4.0]
 
 ### Added

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -60,7 +60,7 @@ def clear_expired_tokens():
     clear_expired(now_minus_expiry_time)
 
 
-def generate_token_for_email(email, user_agent='', ip_address='') -> ResetPasswordToken | None:
+def generate_token_for_email(email, user_agent='', ip_address=''):
     # find a user by email address (case-insensitive search)
     users = User.objects.filter(**{'{}__iexact'.format(get_password_reset_lookup_field()): email})
 

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -60,7 +60,7 @@ def clear_expired_tokens():
     clear_expired(now_minus_expiry_time)
 
 
-def generate_token_for_email(email, user_agent='', ip_address=''):
+def generate_token_for_email(email, user_agent='', ip_address='') -> ResetPasswordToken | None:
     # find a user by email address (case-insensitive search)
     users = User.objects.filter(**{'{}__iexact'.format(get_password_reset_lookup_field()): email})
 
@@ -75,12 +75,14 @@ def generate_token_for_email(email, user_agent='', ip_address=''):
             break
 
     # No active user found, raise a ValidationError
-    # but not if DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True
-    if not active_user_found and not getattr(settings, 'DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE', False):
-        raise exceptions.ValidationError({
-            'email': [_(
-                "We couldn't find an account associated with that email. Please try a different e-mail address.")],
-        })
+    # but not if DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True, in that case we return None
+    if not active_user_found:
+        if not getattr(settings, 'DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE', False):
+            raise exceptions.ValidationError({
+                'email': [_(
+                    "We couldn't find an account associated with that email. Please try a different e-mail address.")],
+            })
+        return None
 
     # last but not least: iterate over all users that are active and can change their password
     # and create a Reset Password Token and send a signal with the created token
@@ -199,9 +201,13 @@ class ResetPasswordRequestToken(GenericAPIView):
             ip_address=request.META.get(HTTP_IP_ADDRESS_HEADER, ''),
         )
 
-        # send a signal that the password token was created
-        # let whoever receives this signal handle sending the email for the password reset
-        reset_password_token_created.send(sender=self.__class__, instance=self, reset_password_token=token)
+        if token:
+            # send a signal that the password token was created
+            # let whoever receives this signal handle sending the email for the password reset
+            reset_password_token_created.send(
+                sender=self.__class__,
+                instance=self, reset_password_token=token
+            )
 
         return Response({'status': 'OK'})
 

--- a/tests/test/test_auth_test_case.py
+++ b/tests/test/test_auth_test_case.py
@@ -360,13 +360,15 @@ class AuthTestCase(APITestCase, HelperMixin):
         self.assertEqual(mock_pre_password_reset.call_args[1]['reset_password_token'], token1)
 
     @override_settings(DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE=True)
-    def test_try_reset_password_email_does_not_exist_no_leakage_enabled(self):
+    @patch('django_rest_passwordreset.signals.reset_password_token_created.send')
+    def test_try_reset_password_email_does_not_exist_no_leakage_enabled(self, mock_reset_signal):
         """
         Tests requesting a token for an email that does not exist when
         DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True
         """
         response = self.rest_do_request_reset_token(email="foobar@doesnotexist.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(mock_reset_signal.called)
 
     def test_user_without_password(self):
         """ Tests requesting a token for an email without a password doesn't work"""


### PR DESCRIPTION
# Bug description

The regression is introduced in V1.4.0 by #181, the [ `the reset_password_token_created.send(...)` signal was fired every time](https://github.com/anexia-it/django-rest-passwordreset/pull/181/files#diff-7bba91b8192566cd09ffdc10b020e0bf92cb9ef6abc88a9484f7b9d81d7285d4R195) when the `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` setting was set to True, even when no user was found and then no reset token created.

When no user was found, the signal was fired with parameter `reset_password_token` at `None` instead of a `Token` object.

# Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (improvements in base code)
- [ ] Add test (adds test coverage to functionality)


# Current MR

This MR proposes a fix of the bug and adds more test coverage. 
The signal is not fired anymore when no token have been created.

Feel free to let me know if you think more tests should be added, or if if you have any other idea on how to improve this fix. 

No other existing behavior should be impacted by this fix, so it might be shipped as a minor version as no breaking change is introduced.

Ideas of improvement (with breaking changes) are described bellow.

# Note

I think that in order to offer a clear interface for programmatically creating tokens (i.e. without using the DRF API), as the initial MR #181 implemented, we could sightly move the code behavior and approach (not implemented in this MR):
- Setting `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` should indeed control is an error is raised or not, but this should be checked [at the view level `django_rest_passwordreset.views.ResetPasswordRequestToken.post`](https://github.com/anexia-it/django-rest-passwordreset/blob/1c69aea7b6713d6efdbc319f1d80bbe09c80605e/django_rest_passwordreset/views.py#L191)
- Move `django_rest_passwordreset.views.generate_token_for_emai`l to a new `utils` module that would also hold the other methods to interact with tokens programmatically.
- Make `django_rest_passwordreset.views.generate_token_for_email` always raise a custom Exception class when no user is found. This method should have a consistent result when no user is found, that way developers can have the `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` setting to `True` to protect their API, and also know what is wrong when an error occurred while creating programmatically a token. Returning None is not giving enough information on what went wrong, and how to fix it.

# Checklist

- [x] Automated tests
- [x] Extends CHANGELOG.md
- [x] Requires migrations? -> NO
- [x] Requires dependency update?  -> NO