### PR TITLE
Update changelog for 1.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 
 ## [Unreleased]
 
+## [1.4.2]
+
+### Fixed
+
+- X-Forwarded-For containing multiple IPs does not respect inet data type (#191)
+
 ## [1.4.1]
 
 ### Fixed
@@ -80,6 +86,8 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 ## [0.9.0]
 - Initial Release
 
+[Unreleased]: https://github.com/anexia-it/django-rest-passwordreset/compare/1.4.2...HEAD
+[1.4.2]: https://github.com/anexia-it/django-rest-passwordreset/compare/1.4.1...1.4.2
 [1.4.1]: https://github.com/anexia-it/django-rest-passwordreset/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/anexia-it/django-rest-passwordreset/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/anexia-it/django-rest-passwordreset/compare/1.2.1...1.3.0


### PR DESCRIPTION
This pull request includes updates to the `CHANGELOG.md` file for the `django-rest-passwordreset` project, documenting the changes for the upcoming 1.4.2 release.

Changelog updates:

* Added a new entry for version 1.4.2, noting a fix related to the `X-Forwarded-For` header containing multiple IPs not respecting the `inet` data type. (`CHANGELOG.md`)
* Updated the links section to include references for the new 1.4.2 version and the comparison link for unreleased changes. (`CHANGELOG.md`)