### PR TITLE
Add throttling to password reset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,18 +66,11 @@ jobs:
         python setup.py install
 
     - name: Run tests
+      working-directory: ./tests
       run: |
-        # prepare Django project: link all necessary data from the test project into the root directory
-        # Hint: Simply changing the directory does not work (leads to missing files in coverage report)
-        ln -s ./tests/test test
-        ln -s ./tests/user_id_uuid_testapp user_id_uuid_testapp
-        ln -s ./tests/manage.py manage.py
-        ln -s ./tests/settings.py settings.py
-        ln -s ./tests/urls.py urls.py
-
-        # run tests with coverage
+        ln -s ../django_rest_passwordreset django_rest_passwordreset
         coverage run --source='./django_rest_passwordreset' manage.py test
-        coverage xml
+        coverage xml -o ../coverage.xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ build/
 .tox/
 db.sqlite3
 dist/
-
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -257,6 +257,20 @@ class RandomStringTokenGenerator(BaseTokenGenerator):
 ```
 
 
+### Throttling
+
+The endpoint to request a reset password token provides throttling.
+Per default the throttling rate is `3/day` per IP address.
+
+The throttling rate can be customized using the `REST_FRAMEWORK` setting and the scope `"django-rest-passwordreset-request-token"`:
+
+```
+REST_FRAMEWORK = {"DEFAULT_THROTTLE_RATES": {"django-rest-passwordreset-request-token": "5/hour"}}
+```
+
+See also: https://www.django-rest-framework.org/api-guide/throttling/#setting-the-throttling-policy
+
+
 ## Compatibility Matrix
 
 This library should be compatible with the latest Django and Django Rest Framework Versions. For reference, here is

--- a/django_rest_passwordreset/throttling.py
+++ b/django_rest_passwordreset/throttling.py
@@ -1,0 +1,16 @@
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework.throttling import UserRateThrottle
+
+
+__all__ = ("ResetPasswordRequestTokenThrottle",)
+
+
+class ResetPasswordRequestTokenThrottle(UserRateThrottle):
+    scope = "django-rest-passwordreset-request-token"
+    default_rate = "3/day"
+
+    def get_rate(self):
+        try:
+            return super().get_rate()
+        except ImproperlyConfigured:
+            return self.default_rate

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -16,6 +16,7 @@ from django_rest_passwordreset.models import ResetPasswordToken, clear_expired, 
     get_password_reset_lookup_field
 from django_rest_passwordreset.serializers import EmailSerializer, PasswordTokenSerializer, ResetTokenSerializer
 from django_rest_passwordreset.signals import reset_password_token_created, pre_password_reset, post_password_reset
+from django_rest_passwordreset.throttling import ResetPasswordRequestTokenThrottle
 
 User = get_user_model()
 
@@ -185,7 +186,7 @@ class ResetPasswordRequestToken(GenericAPIView):
 
     Sends a signal reset_password_token_created when a reset token was created
     """
-    throttle_classes = ()
+    throttle_classes = (ResetPasswordRequestTokenThrottle,)
     permission_classes = ()
     serializer_class = EmailSerializer
     authentication_classes = ()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -127,3 +127,10 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 AUTH_USER_MODEL = "user_id_uuid_testapp.User"
+
+REST_FRAMEWORK = {
+    "DEFAULT_THROTTLE_RATES": {
+        "django-rest-passwordreset-request-token": "99999/second",
+        "django-rest-passwordreset-request-token-test-scope": "1/day",
+    },
+}

--- a/tests/test/test_throttle.py
+++ b/tests/test/test_throttle.py
@@ -1,0 +1,70 @@
+from unittest import mock
+
+from rest_framework.test import APIClient, APITestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from django_rest_passwordreset.models import ResetPasswordToken
+
+
+User = get_user_model()
+
+
+class TestThrottle(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        self.user_1 = User.objects.create_user(username='user_1', password='password', email='user@test.local')
+        self.user_admin = User.objects.create_superuser(username='admin', password='password', email='admin@test.local')
+
+    def _reset_password_logged_in(self):
+
+        # generate token
+        url = reverse('password_reset:reset-password-request')
+        data = {'email': self.user_1.email}
+        response = self.client.post(url, data).json()
+
+        self.assertIn('status', response)
+        self.assertEqual(response['status'], 'OK')
+
+        # test validity of the token
+        token = ResetPasswordToken.objects.filter(user=self.user_1).first()
+        url = reverse('password_reset:reset-password-validate')
+        data = {'token': token.key}
+        response = self.client.post(url, data).json()
+
+        self.assertIn('status', response)
+        self.assertEqual(response['status'], 'OK')
+
+        # reset password
+        url = reverse('password_reset:reset-password-confirm')
+        data = {'token': token.key, 'password': 'new_password'}
+        response = self.client.post(url, data).json()
+
+        # check if new password was set
+        self.assertTrue(token.user.check_password('new_password'))
+        self.assertFalse(token.user.check_password('password'))
+
+    @mock.patch(
+        "django_rest_passwordreset.throttling.ResetPasswordRequestTokenThrottle.scope",
+        "django-rest-passwordreset-request-token-test-scope",
+    )
+    def test_throttle(self,):
+        # first run on _reset_password_logged_in
+        # x number of runs (adjust number of calls to the throttle rate)
+        for _ in range(1):
+            self._reset_password_logged_in()
+        # last run should raise an exception
+        self.assertRaises(Exception, self._reset_password_logged_in)
+
+    @mock.patch(
+        "django_rest_passwordreset.throttling.ResetPasswordRequestTokenThrottle.scope",
+        "django-rest-passwordreset-request-token-does-not-exist",
+    )
+    def test_throttle_default_rate(self):
+        # first run on _reset_password_logged_in
+        # x number of runs (adjust number of calls to the throttle rate)
+        for _ in range(3):
+            self._reset_password_logged_in()
+        # last run should raise an exception
+        self.assertRaises(Exception, self._reset_password_logged_in)


### PR DESCRIPTION
Build on top of https://github.com/anexia-it/django-rest-passwordreset/pull/189 and https://github.com/anexia-it/django-rest-passwordreset/pull/199

This pull request introduces a throttling mechanism for the password reset token request endpoint and updates the test setup to accommodate these changes. 

**CI Workflow**: Modified the GitHub Actions workflow to set the working directory for running tests and updated the coverage report generation.