### PR TITLE
Remove test files from package distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 - Updated CI/CD pipelines to test currently supported Django/Python combinations
 - Updated PostgreSQL test service to version 14 (required by Django 5.2)
 
+### Fixed
+- Excluded the library's `tests` package from installation to prevent import shadowing (for example `ModuleNotFoundError: No module named 'tests.plugins'` in consumer projects using pytest).
+
 ## [1.5.0]
 
 - Added Python 3.13 support

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 setup(
     name='django-rest-passwordreset',
     version=os.getenv('PACKAGE_VERSION', '0.0.0').replace('refs/tags/', ''),
-    packages=find_packages(),
+    # Exclude the local test suite from distribution packages to avoid
+    # shadowing consumers' own `tests` modules after installation.
+    packages=find_packages(exclude=('tests', 'tests.*')),
     include_package_data=True,
     license='BSD License',
     description='An extension of django rest framework, providing a configurable password reset strategy',


### PR DESCRIPTION
This pull request addresses an issue where the library's internal `tests` package was being installed.

Packaging improvements:

* Updated `setup.py` to exclude the library's `tests` package from distribution, avoiding import shadowing in consumer projects.
* Added a changelog entry documenting the exclusion of the `tests` package to prevent import errors in consumer projects.