### PR TITLE
Change DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE default from False to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,27 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 - Added Django 6.0 support
 - Added Django Rest Framework 3.16 support
 
+### Security
+
+- The reset-token request endpoint (`POST .../reset_password/`) no longer exposes whether an
+  account exists via HTTP status or response body. Previously, by default, a request for a
+  non-existent (or inactive / no-usable-password) account returned HTTP 400 with an `email` error,
+  while an existing account returned HTTP 200 — a user-enumeration oracle (CWE-204). The default is
+  now to always return HTTP 200 with a generic body, matching the behavior of Django's built-in
+  password reset and common industry practice.
+  - The `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` setting now defaults to `True`.
+  - Explicitly setting it to `False` re-enables the legacy 400-based oracle; this opt-in is
+    deprecated and will be removed in a future major release.
+  - Note: a residual timing side channel remains (the existing-account path performs a DB write and
+    fires `reset_password_token_created`, which often triggers an SMTP send). The response-status
+    oracle is closed; the timing channel is not. A future hardening pass may equalize the two paths.
+
 ### Changed
+
+- **Breaking:** `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` default changed from `False` to `True`.
+  Clients that rendered UI based on the previous 400 response for unknown emails will now always receive 200.
+  Set `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE = False` to temporarily restore the legacy behavior
+  (deprecated).
 - Removed Django 4.2 and 5.1 from the supported/tested matrix
 - Updated CI/CD pipelines to test currently supported Django/Python combinations
 - Updated PostgreSQL test service to version 14 (required by Django 5.2)

--- a/README.md
+++ b/README.md
@@ -138,8 +138,13 @@ The following settings can be set in Django ``settings.py`` file:
 
   **Please note**: expired tokens are automatically cleared based on this setting in every call of ``ResetPasswordRequestToken.post``.
 
-* `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` - will cause a 200 to be returned on `POST ${API_URL}/reset_password/`
-  even if the user doesn't exist in the databse (Default: False) 
+* `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` - when `True` (the default in the next release), a `200 OK` is
+  always returned on `POST ${API_URL}/reset_password/`, even if the user does not exist in the database,
+  so the endpoint does not expose account existence via HTTP status or response body (CWE-204). Setting this
+  to `False` restores the legacy behavior of returning a `400` for unknown accounts; this re-enables the
+  enumeration oracle and is **deprecated** (will be removed in a future major release).
+  Note: even with the default, a timing side channel may still distinguish existing from non-existing
+  accounts (the existing-account path performs a DB write and fires `reset_password_token_created`).
 
 * `DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD` - allows password reset for a user that does not 
   [have a usable password](https://docs.djangoproject.com/en/2.2/ref/contrib/auth/#django.contrib.auth.models.User.has_usable_password) (Default: True)

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -75,15 +75,24 @@ def generate_token_for_email(email, user_agent='', ip_address=''):
             active_user_found = True
             break
 
-    # No active user found, raise a ValidationError
-    # but not if DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True, in that case we return None
+    # No active user found.
+    #
+    # By default (DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE is unset or True) we return None
+    # so that the caller responds with a generic 200 OK, identical to the response for an existing
+    # account. This avoids a status/body user-enumeration oracle (distinct 400 vs 200 based on
+    # account existence).
+    #
+    # The previous default (False) raised a ValidationError -> 400, leaking whether an account exists.
+    # That behavior is retained only as an explicit opt-in and is deprecated; it will be removed in a
+    # future major release.
     if not active_user_found:
-        if not getattr(settings, 'DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE', False):
-            raise exceptions.ValidationError({
-                'email': [_(
-                    "We couldn't find an account associated with that email. Please try a different e-mail address.")],
-            })
-        return None
+        no_information_leakage = getattr(settings, 'DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE', True)
+        if no_information_leakage:
+            return None
+        raise exceptions.ValidationError({
+            'email': [_(
+                "We couldn't find an account associated with that email. Please try a different e-mail address.")],
+        })
 
     # last but not least: iterate over all users that are active and can change their password
     # and create a Reset Password Token and send a signal with the created token

--- a/tests/test/test_auth_test_case.py
+++ b/tests/test/test_auth_test_case.py
@@ -28,12 +28,16 @@ class AuthTestCase(APITestCase, HelperMixin):
         self.user5 = User.objects.create_user("user5", "uѕer5@mail.com", "secret5")  # email contains kyrillic s
 
     def test_try_reset_password_email_does_not_exist(self):
-        """ Tests requesting a token for an email that does not exist """
+        """ Tests requesting a token for an email that does not exist returns a generic 200 (no oracle) """
+        # By default, a non-existent account returns 200 OK, identical to the response for an
+        # existing account, so the endpoint does not expose existence via status or response body.
         response = self.rest_do_request_reset_token(email="foobar@doesnotexist.com")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         decoded_response = json.loads(response.content.decode())
-        # response should have "email" in it
-        self.assertTrue("email" in decoded_response)
+        # no account-specific error details should be present in the body
+        self.assertFalse("email" in decoded_response)
+        # and no token should have been created
+        self.assertEqual(ResetPasswordToken.objects.all().count(), 0)
 
     def test_unicode_email_reset(self):
         response = self.rest_do_request_reset_token(email="uѕer5@mail.com")
@@ -365,20 +369,32 @@ class AuthTestCase(APITestCase, HelperMixin):
     @patch('django_rest_passwordreset.signals.reset_password_token_created.send')
     def test_try_reset_password_email_does_not_exist_no_leakage_enabled(self, mock_reset_signal):
         """
-        Tests requesting a token for an email that does not exist when
-        DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True
+        Tests requesting a token for an email that does not exist returns 200 OK
+        when DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE == True (explicit opt-in
+        to the default behavior).
         """
         response = self.rest_do_request_reset_token(email="foobar@doesnotexist.com")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(mock_reset_signal.called)
 
-    def test_user_without_password(self):
-        """ Tests requesting a token for an email without a password doesn't work"""
-        response = self.rest_do_request_reset_token(email="user4@mail.com")
+    @override_settings(DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE=False)
+    def test_try_reset_password_email_does_not_exist_leakage_opt_in_legacy_behavior(self):
+        """
+        The deprecated DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE=False opt-in still
+        re-enables the 400-based user-enumeration oracle.
+        """
+        response = self.rest_do_request_reset_token(email="foobar@doesnotexist.com")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         decoded_response = json.loads(response.content.decode())
-        # response should have "email" in it
         self.assertTrue("email" in decoded_response)
+
+    def test_user_without_password(self):
+        """ Tests requesting a token for a user without password returns a generic 200 (no oracle) """
+        # Under the default (no-information-leakage) behavior, a user with no usable password is
+        # treated the same as a non-existent account: 200 OK, no token created.
+        response = self.rest_do_request_reset_token(email="user4@mail.com")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(ResetPasswordToken.objects.all().count(), 0)
 
     @override_settings(DJANGO_REST_MULTITOKENAUTH_REQUIRE_USABLE_PASSWORD=False)
     @patch('django_rest_passwordreset.signals.reset_password_token_created.send')


### PR DESCRIPTION
Introduces an improvement to the password reset endpoint by preventing user enumeration attacks via HTTP status or response body. The default behavior now always returns HTTP 200 for password reset requests, regardless of whether the account exists, aligning with best practices. The legacy behavior can be temporarily restored but is deprecated. Tests and documentation are updated to reflect this change.

**Security improvements:**

* The reset-token request endpoint (`POST .../reset_password/`) now always returns HTTP 200 with a generic response, preventing attackers from determining if an account exists based on the response status or body. The `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` setting now defaults to `True`.

**Breaking changes:**

* The default for `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` is now `True`, changing the response for unknown emails from HTTP 400 to HTTP 200. Explicitly setting it to `False` restores the old behavior but is deprecated and will be removed in a future major release.
