### PR TITLE
Respect DRF throttles on reset validate/confirm endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,19 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 - Added Django 5.2 LTS support
 - Added Django 6.0 support
 - Added Django Rest Framework 3.16 support
+- Added `DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES` to replace the request-token endpoint throttle
+  classes. The default remains `ResetPasswordRequestTokenThrottle`; setting it to an empty list
+  delegates the request-token endpoint to DRF's global `DEFAULT_THROTTLE_CLASSES`.
 
 ### Security
 
+- The token-validation and password-confirm endpoints no longer declare `throttle_classes = ()`, so
+  an operator's global `REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"]` is now respected on those flows.
+  Previously, the empty-tuple declaration silently overrode global throttle configuration on these
+  security-critical endpoints (CWE-307 / CWE-799). The request-token endpoint retains the library's
+  `ResetPasswordRequestTokenThrottle` and built-in `3/day` fallback. This enables configured global
+  throttles for token validation and password confirmation; it does not add a new built-in throttle
+  to those endpoints.
 - The reset-token request endpoint (`POST .../reset_password/`) no longer exposes whether an
   account exists via HTTP status or response body. Previously, by default, a request for a
   non-existent (or inactive / no-usable-password) account returned HTTP 400 with an `email` error,
@@ -35,6 +45,15 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
   Clients that rendered UI based on the previous 400 response for unknown emails will now always receive 200.
   Set `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE = False` to temporarily restore the legacy behavior
   (deprecated).
+- **Breaking:** Global DRF throttles now apply to the token-validation and password-confirm endpoints.
+  Deployments that configure `REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"]` may now receive HTTP 429 from
+  those endpoints where earlier versions bypassed the global throttles. For `ScopedRateThrottle`, the
+  endpoint scopes are `django-rest-passwordreset-validate-token` and
+  `django-rest-passwordreset-confirm`. If the request-token endpoint is delegated to global throttles
+  with `DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES = []`, its scope is
+  `django-rest-passwordreset-request-token`. Any active `ScopedRateThrottle` scope must have a matching
+  `REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]` entry; otherwise the affected endpoint raises
+  `ImproperlyConfigured` (HTTP 500).
 - Removed Django 4.2 and 5.1 from the supported/tested matrix
 - Updated CI/CD pipelines to test currently supported Django/Python combinations
 - Updated PostgreSQL test service to version 14 (required by Django 5.2)

--- a/README.md
+++ b/README.md
@@ -265,15 +265,66 @@ class RandomStringTokenGenerator(BaseTokenGenerator):
 ### Throttling
 
 The endpoint to request a reset password token provides throttling.
-Per default the throttling rate is `3/day` per IP address.
+Per default the throttling rate is `3/day` per IP address, applied via the library's
+`ResetPasswordRequestTokenThrottle` (a DRF `UserRateThrottle` scoped to
+`"django-rest-passwordreset-request-token"`).
 
-The throttling rate can be customized using the `REST_FRAMEWORK` setting and the scope `"django-rest-passwordreset-request-token"`:
+The throttling rate can be customized using the `REST_FRAMEWORK` setting and the scope
+`"django-rest-passwordreset-request-token"`:
 
 ```
 REST_FRAMEWORK = {"DEFAULT_THROTTLE_RATES": {"django-rest-passwordreset-request-token": "5/hour"}}
 ```
 
+The request-token throttle classes can also be replaced:
+
+```
+DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES = [
+    "rest_framework.throttling.AnonRateThrottle",
+]
+```
+
+By default, this setting is unset and the endpoint uses `ResetPasswordRequestTokenThrottle`. Setting
+`DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES = []` delegates the request-token endpoint to DRF's global
+`DEFAULT_THROTTLE_CLASSES` instead. If you do this, configure an equivalent global throttle; otherwise
+you remove the built-in `3/day` request-token protection. For `ScopedRateThrottle`, the request-token
+scope is `"django-rest-passwordreset-request-token"`.
+
+The token-validation and password-confirm endpoints do not declare their own `throttle_classes`, so
+an operator's `REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"]` is respected for those endpoints. In earlier
+versions, those endpoints declared `throttle_classes = ()` and silently bypassed global throttles.
+
+The request-token endpoint is intentionally different by default: it uses its configured
+`DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES`, so global `DEFAULT_THROTTLE_CLASSES` do not additionally
+stack on that endpoint unless you set `DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES = []`.
+
+For example, to use DRF's scoped throttling for all three password-reset endpoints:
+
+```
+DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES = []
+
+REST_FRAMEWORK = {
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.ScopedRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "django-rest-passwordreset-request-token": "5/hour",
+        "django-rest-passwordreset-validate-token": "60/minute",
+        "django-rest-passwordreset-confirm": "10/hour",
+    },
+}
+```
+
+When `ScopedRateThrottle` is active on any password-reset endpoint, every active scope must have a
+matching entry in `DEFAULT_THROTTLE_RATES`. Omitting a rate for
+`django-rest-passwordreset-request-token`, `django-rest-passwordreset-validate-token`, or
+`django-rest-passwordreset-confirm` causes the affected endpoint to raise `ImproperlyConfigured`
+(HTTP 500).
+
 See also: https://www.django-rest-framework.org/api-guide/throttling/#setting-the-throttling-policy
+
+If you use `AnonRateThrottle` or `UserRateThrottle` globally, configure the standard DRF `anon` and
+`user` rates instead.
 
 
 ## Compatibility Matrix

--- a/django_rest_passwordreset/throttling.py
+++ b/django_rest_passwordreset/throttling.py
@@ -1,8 +1,11 @@
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.module_loading import import_string
+from rest_framework.settings import api_settings
 from rest_framework.throttling import UserRateThrottle
 
 
-__all__ = ("ResetPasswordRequestTokenThrottle",)
+__all__ = ("ResetPasswordRequestTokenThrottle", "get_password_reset_request_token_throttle_classes")
 
 
 class ResetPasswordRequestTokenThrottle(UserRateThrottle):
@@ -14,3 +17,24 @@ class ResetPasswordRequestTokenThrottle(UserRateThrottle):
             return super().get_rate()
         except ImproperlyConfigured:
             return self.default_rate
+
+
+def _resolve_throttle_class(throttle_class):
+    if isinstance(throttle_class, str):
+        return import_string(throttle_class)
+    return throttle_class
+
+
+def get_password_reset_request_token_throttle_classes():
+    throttle_classes = getattr(settings, 'DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES', None)
+
+    if throttle_classes is None:
+        return (ResetPasswordRequestTokenThrottle,)
+
+    if isinstance(throttle_classes, str):
+        throttle_classes = (throttle_classes,)
+
+    if not throttle_classes:
+        return tuple(api_settings.DEFAULT_THROTTLE_CLASSES)
+
+    return tuple(_resolve_throttle_class(throttle_class) for throttle_class in throttle_classes)

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -16,7 +16,7 @@ from django_rest_passwordreset.models import ResetPasswordToken, clear_expired, 
     get_password_reset_lookup_field
 from django_rest_passwordreset.serializers import EmailSerializer, PasswordTokenSerializer, ResetTokenSerializer
 from django_rest_passwordreset.signals import reset_password_token_created, pre_password_reset, post_password_reset
-from django_rest_passwordreset.throttling import ResetPasswordRequestTokenThrottle
+from django_rest_passwordreset.throttling import get_password_reset_request_token_throttle_classes
 
 User = get_user_model()
 
@@ -117,10 +117,10 @@ class ResetPasswordValidateToken(GenericAPIView):
     """
     An Api View which provides a method to verify that a token is valid
     """
-    throttle_classes = ()
     permission_classes = ()
     serializer_class = ResetTokenSerializer
     authentication_classes = ()
+    throttle_scope = 'django-rest-passwordreset-validate-token'
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)
@@ -141,10 +141,10 @@ class ResetPasswordConfirm(GenericAPIView):
     """
     An Api View which provides a method to reset a password based on a unique token
     """
-    throttle_classes = ()
     permission_classes = ()
     serializer_class = PasswordTokenSerializer
     authentication_classes = ()
+    throttle_scope = 'django-rest-passwordreset-confirm'
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)
@@ -195,10 +195,17 @@ class ResetPasswordRequestToken(GenericAPIView):
 
     Sends a signal reset_password_token_created when a reset token was created
     """
-    throttle_classes = (ResetPasswordRequestTokenThrottle,)
     permission_classes = ()
     serializer_class = EmailSerializer
     authentication_classes = ()
+    # Used when DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES delegates to ScopedRateThrottle.
+    throttle_scope = 'django-rest-passwordreset-request-token'
+
+    def get_throttles(self):
+        return [
+            throttle_class()
+            for throttle_class in get_password_reset_request_token_throttle_classes()
+        ]
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)

--- a/tests/test/test_throttle.py
+++ b/tests/test/test_throttle.py
@@ -1,10 +1,21 @@
 from unittest import mock
 
-from rest_framework.test import APIClient, APITestCase
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle
+from rest_framework.views import APIView
 
 from django_rest_passwordreset.models import ResetPasswordToken
+from django_rest_passwordreset.throttling import (
+    ResetPasswordRequestTokenThrottle,
+    get_password_reset_request_token_throttle_classes,
+)
+from django_rest_passwordreset.views import ResetPasswordConfirm, ResetPasswordRequestToken, ResetPasswordValidateToken
 
 
 User = get_user_model()
@@ -12,13 +23,13 @@ User = get_user_model()
 
 class TestThrottle(APITestCase):
     def setUp(self):
+        cache.clear()
         self.client = APIClient()
 
         self.user_1 = User.objects.create_user(username='user_1', password='password', email='user@test.local')
         self.user_admin = User.objects.create_superuser(username='admin', password='password', email='admin@test.local')
 
     def _reset_password_logged_in(self):
-
         # generate token
         url = reverse('password_reset:reset-password-request')
         data = {'email': self.user_1.email}
@@ -44,6 +55,133 @@ class TestThrottle(APITestCase):
         # check if new password was set
         self.assertTrue(token.user.check_password('new_password'))
         self.assertFalse(token.user.check_password('password'))
+
+    def test_request_token_endpoint_keeps_library_throttle_default(self):
+        throttles = ResetPasswordRequestToken().get_throttles()
+        self.assertEqual(len(throttles), 1)
+        self.assertIsInstance(throttles[0], ResetPasswordRequestTokenThrottle)
+
+    def test_request_token_throttle_classes_default_to_library_throttle(self):
+        self.assertEqual(
+            get_password_reset_request_token_throttle_classes(),
+            (ResetPasswordRequestTokenThrottle,),
+        )
+
+    @override_settings(
+        DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES=["rest_framework.throttling.AnonRateThrottle"],
+    )
+    def test_request_token_throttle_classes_can_be_replaced(self):
+        self.assertEqual(
+            get_password_reset_request_token_throttle_classes(),
+            (AnonRateThrottle,),
+        )
+
+    @override_settings(
+        DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES=[],
+        REST_FRAMEWORK={
+            "DEFAULT_THROTTLE_CLASSES": [
+                "rest_framework.throttling.AnonRateThrottle",
+            ],
+        },
+    )
+    def test_empty_request_token_throttle_classes_delegate_to_drf_defaults(self):
+        self.assertEqual(
+            get_password_reset_request_token_throttle_classes(),
+            (AnonRateThrottle,),
+        )
+
+    @override_settings(
+        DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES=["rest_framework.throttling.ScopedRateThrottle"],
+    )
+    def test_request_token_endpoint_uses_configured_throttle_classes(self):
+        self._assert_endpoint_uses_scoped_throttle(
+            reverse('password_reset:reset-password-request'),
+            {'email': self.user_1.email},
+            ResetPasswordRequestToken.throttle_scope,
+            '192.0.2.30',
+        )
+
+    @override_settings(
+        DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES=[],
+        REST_FRAMEWORK={
+            "DEFAULT_THROTTLE_CLASSES": [
+                "rest_framework.throttling.ScopedRateThrottle",
+            ],
+        },
+    )
+    def test_empty_request_token_throttle_classes_endpoint_uses_drf_defaults(self):
+        self._assert_endpoint_uses_scoped_throttle(
+            reverse('password_reset:reset-password-request'),
+            {'email': self.user_1.email},
+            ResetPasswordRequestToken.throttle_scope,
+            '192.0.2.40',
+        )
+
+    @override_settings(
+        DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES=[],
+        REST_FRAMEWORK={
+            "DEFAULT_THROTTLE_CLASSES": [
+                "rest_framework.throttling.ScopedRateThrottle",
+            ],
+        },
+    )
+    def test_scoped_throttle_without_matching_rate_raises_improperly_configured(self):
+        cache.clear()
+        with mock.patch.object(ScopedRateThrottle, "THROTTLE_RATES", {}):
+            with self.assertRaises(ImproperlyConfigured):
+                self.client.post(
+                    reverse('password_reset:reset-password-request'),
+                    {'email': self.user_1.email},
+                    format='json',
+                    REMOTE_ADDR='192.0.2.50',
+                )
+
+    def test_validate_and_confirm_endpoints_do_not_override_global_throttle_classes(self):
+        for view_class in (ResetPasswordValidateToken, ResetPasswordConfirm):
+            self.assertNotIn("throttle_classes", view_class.__dict__)
+
+    def test_password_reset_endpoints_expose_scoped_throttle_names(self):
+        self.assertEqual(
+            ResetPasswordRequestToken.throttle_scope,
+            "django-rest-passwordreset-request-token",
+        )
+        self.assertEqual(
+            ResetPasswordValidateToken.throttle_scope,
+            "django-rest-passwordreset-validate-token",
+        )
+        self.assertEqual(
+            ResetPasswordConfirm.throttle_scope,
+            "django-rest-passwordreset-confirm",
+        )
+
+    def _assert_endpoint_uses_scoped_throttle(self, url, data, scope, remote_addr):
+        cache.clear()
+        with mock.patch.object(ScopedRateThrottle, "THROTTLE_RATES", {scope: "1/day"}):
+            response = self.client.post(url, data, format='json', REMOTE_ADDR=remote_addr)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            response = self.client.post(url, data, format='json', REMOTE_ADDR=remote_addr)
+            self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_validate_endpoint_uses_inherited_scoped_throttle(self):
+        token = ResetPasswordToken.objects.create(user=self.user_1)
+        with mock.patch.object(APIView, "throttle_classes", (ScopedRateThrottle,)):
+            self._assert_endpoint_uses_scoped_throttle(
+                reverse('password_reset:reset-password-validate'),
+                {'token': token.key},
+                ResetPasswordValidateToken.throttle_scope,
+                '192.0.2.10',
+            )
+
+    def test_confirm_endpoint_uses_inherited_scoped_throttle(self):
+        token = ResetPasswordToken.objects.create(user=self.user_1)
+        with mock.patch.object(APIView, "throttle_classes", (ScopedRateThrottle,)):
+            self._assert_endpoint_uses_scoped_throttle(
+                reverse('password_reset:reset-password-confirm'),
+                {'token': token.key, 'password': 'new_password'},
+                ResetPasswordConfirm.throttle_scope,
+                '192.0.2.20',
+            )
 
     @mock.patch(
         "django_rest_passwordreset.throttling.ResetPasswordRequestTokenThrottle.scope",


### PR DESCRIPTION
Significant improvements and configurability to throttling for password reset endpoints, including a new setting for customizing throttle classes, better alignment with global DRF throttle settings, and enhanced security. The changes also include updated documentation and comprehensive tests to validate the new behavior.

**Throttling configuration and behavior:**

* Added the `DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES` setting, allowing operators to replace or delegate the request-token endpoint's throttle classes. By default, the library's `ResetPasswordRequestTokenThrottle` is used; setting this to an empty list delegates throttling to DRF's global `DEFAULT_THROTTLE_CLASSES`.
* The token-validation and password-confirm endpoints no longer override global throttling by declaring `throttle_classes = ()`. They now respect `REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"]`, making global throttles effective on these endpoints.
* Introduced explicit `throttle_scope` attributes for all three endpoints, enabling use of DRF's `ScopedRateThrottle` and requiring matching entries in `DEFAULT_THROTTLE_RATES` when used. Missing rates now raise `ImproperlyConfigured` as expected.

**Documentation and breaking changes:**

* Updated `README.md` and `CHANGELOG.md` to document the new configuration options, clarify the default and customizable throttling behavior, and highlight the breaking change that global throttles now apply to token-validation and password-confirm endpoints.

**Testing improvements:**

* Added comprehensive tests to ensure correct throttle class selection, delegation to DRF defaults, enforcement of required throttle rates, and that endpoints expose the correct throttle scopes.
