### PR TITLE
Document expired token cleanup and index created_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 - Added `DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES` to replace the request-token endpoint throttle
   classes. The default remains `ResetPasswordRequestTokenThrottle`; setting it to an empty list
   delegates the request-token endpoint to DRF's global `DEFAULT_THROTTLE_CLASSES`.
+- Added a database index on `ResetPasswordToken.created_at` so expired-token cleanup
+  (`clearresetpasswodtokens` and the request-token endpoint's `clear_expired_tokens`) can use an
+  indexed range filter before deleting matching rows. Documented scheduling the
+  `clearresetpasswodtokens` management command (cron, Celery beat, or django-future-tasks) as the
+  recommended way to keep the token table small; the validate/confirm endpoints intentionally do not
+  run bulk cleanup.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,34 @@ The following settings can be set in Django ``settings.py`` file:
 
 * `DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME` - time in hours about how long the token is active (Default: 24)
 
-  **Please note**: expired tokens are automatically cleared based on this setting in every call of ``ResetPasswordRequestToken.post``.
+  **Please note**: expired tokens are automatically cleared based on this setting in every call of ``ResetPasswordRequestToken.post``. The token-validation and password-confirm endpoints do **not** run this bulk cleanup (an expired token presented there is rejected and deleted individually by the serializer); running a full-table cleanup on those high-frequency, attack-exposed endpoints would be a DoS amplification vector. For reliable DB hygiene without relying on reset requests coming in, schedule the management command below.
+
+### Token cleanup (expired-token removal)
+
+The package ships a management command to bulk-remove expired tokens:
+
+```
+python manage.py clearresetpasswodtokens
+```
+
+It deletes every ``ResetPasswordToken`` with ``created_at`` older than
+``DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME`` hours. **Schedule it** (cron, systemd timer,
+Celery beat, Django-Q, or
+[django-future-tasks](https://pypi.org/project/django-future-tasks/)) for periodic DB hygiene — for
+example once an hour or once a day:
+
+```
+# crontab example: clear expired reset tokens every hour at :05
+5 * * * * /path/to/venv/bin/python /path/to/manage.py clearresetpasswodtokens
+```
+
+This is the recommended way to keep the token table small. The cleanup query filters on indexed
+``created_at`` values, avoiding an unindexed scan before deleting matching rows.
+
+Individual expired tokens are *also* removed on use: when an expired token is submitted to the
+validate or confirm endpoint, the serializer deletes that single token and rejects the request
+(HTTP 404). The bulk command above is therefore about reclaiming rows for tokens that are never
+presented again, not about security enforcement.
 
 * `DJANGO_REST_PASSWORDRESET_NO_INFORMATION_LEAKAGE` - when `True` (the default in the next release), a `200 OK` is
   always returned on `POST ${API_URL}/reset_password/`, even if the user does not exist in the database,

--- a/django_rest_passwordreset/migrations/0005_resetpasswordtoken_created_at_index.py
+++ b/django_rest_passwordreset/migrations/0005_resetpasswordtoken_created_at_index.py
@@ -1,0 +1,19 @@
+# Generated for django-rest-passwordreset: index ResetPasswordToken.created_at to
+# speed up expired-token cleanup (`created_at__lte` range scan used by the
+# `clearresetpasswodtokens` management command and the request-token endpoint).
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_rest_passwordreset', '0004_alter_resetpasswordtoken_user_agent'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='resetpasswordtoken',
+            index=models.Index(fields=['created_at'], name='drpr_token_created_at_idx'),
+        ),
+    ]

--- a/django_rest_passwordreset/models.py
+++ b/django_rest_passwordreset/models.py
@@ -27,6 +27,11 @@ class ResetPasswordToken(models.Model):
     class Meta:
         verbose_name = _("Password Reset Token")
         verbose_name_plural = _("Password Reset Tokens")
+        # Speeds up `clear_expired` (a `created_at__lte` range scan + bulk delete) used by the
+        # `clearresetpasswodtokens` management command and the request-token endpoint cleanup.
+        indexes = [
+            models.Index(fields=["created_at"], name="drpr_token_created_at_idx"),
+        ]
 
     @staticmethod
     def generate_key():


### PR DESCRIPTION
Improvements to the expired password reset token cleanup process in the `django-rest-passwordreset` package. The main change is the addition of a database index on the `created_at` field of the `ResetPasswordToken` model, which significantly speeds up bulk deletion of expired tokens.

The documentation is also updated to recommend scheduling the provided management command for regular cleanup, rather than relying on endpoint-triggered cleanup.