### PR TITLE
Add security warning for RandomNumberTokenGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 
 ### Security
 
+- Documented a security warning for `RandomNumberTokenGenerator`: the default 5-digit numeric range
+  has only about 90,000 possible values and can be brute-forced in roughly a day at one guess per
+  second against the validate/confirm endpoints. The README example now uses a much larger numeric
+  range, and a warning was added to the class docstring. `RandomStringTokenGenerator` remains the
+  safer default.
 - The token-validation and password-confirm endpoints no longer declare `throttle_classes = ()`, so
   an operator's global `REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"]` is now respected on those flows.
   Previously, the empty-tuple declaration silently overrode global throttle configuration on these

--- a/README.md
+++ b/README.md
@@ -237,19 +237,29 @@ It uses `os.urandom()` to generate a good random string.
    
 
 ### RandomNumberTokenGenerator
+
+> **Security warning:** Numeric tokens have a much smaller search space than the default string
+> tokens. The default range (`10000`–`99999`, about 90,000 values) can be exhausted in roughly a day
+> at one guess per second against the token-validation or password-confirm endpoint, and faster
+> without effective throttling. Use `RandomNumberTokenGenerator` only when numeric reset codes are
+> required. If you use it, choose a large range and throttle validate/confirm (see
+> [Throttling](#throttling)). For most deployments, `RandomStringTokenGenerator` remains the safer
+> default.
+
 ```python
 DJANGO_REST_PASSWORDRESET_TOKEN_CONFIG = {
     "CLASS": "django_rest_passwordreset.tokens.RandomNumberTokenGenerator"
 }
 ```
 
-You can configure the minimum and maximum number as follows:
+Configure the minimum and maximum value as follows. This example produces 10-digit numeric tokens
+with about 9 billion possible values; use it together with validate/confirm throttling:
 ```python
 DJANGO_REST_PASSWORDRESET_TOKEN_CONFIG = {
     "CLASS": "django_rest_passwordreset.tokens.RandomNumberTokenGenerator",
     "OPTIONS": {
-        "min_number": 1500,
-        "max_number": 9999
+        "min_number": 1000000000,
+        "max_number": 9999999999
     }
 }
 ```

--- a/django_rest_passwordreset/tokens.py
+++ b/django_rest_passwordreset/tokens.py
@@ -72,6 +72,14 @@ class RandomStringTokenGenerator(BaseTokenGenerator):
 class RandomNumberTokenGenerator(BaseTokenGenerator):
     """
     Generates a random number using random.SystemRandom() (which uses urandom in the background)
+
+    .. warning::
+        Numeric tokens have a much smaller search space than the default string tokens. The default
+        range (10000-99999, about 90,000 values) can be exhausted in roughly a day at one guess per
+        second against the validate/confirm endpoints, and faster without effective throttling.
+        Prefer ``RandomStringTokenGenerator`` unless numeric reset codes are required. If you use
+        numeric tokens, set a large ``min_number``/``max_number`` range and throttle the
+        validate/confirm endpoints. See the README "RandomNumberTokenGenerator" section.
     """
     def __init__(self, min_number=10000, max_number=99999, *args, **kwargs):
         self.min_number = min_number


### PR DESCRIPTION
Security documentation improvements:

* Added a detailed security warning to the `RandomNumberTokenGenerator` class docstring, explaining the brute-force risk of the default numeric range and recommending the use of larger ranges and endpoint throttling.
* Updated the `README.md` to include a prominent security warning about the risks of numeric tokens, and provided an example configuration using a 10-digit range for improved security.
* Documented the security warning in the `CHANGELOG.md`, clarifying the brute-force vulnerability of the default range and the safer default of `RandomStringTokenGenerator`.