### PR TITLE
Harden reset token failure responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
   - Note: a residual timing side channel remains (the existing-account path performs a DB write and
     fires `reset_password_token_created`, which often triggers an SMTP send). The response-status
     oracle is closed; the timing channel is not. A future hardening pass may equalize the two paths.
+- The token-validation and password-confirm endpoints now use the same generic HTTP 404 response for
+  missing, malformed, expired, and ineligible-user tokens. Expired tokens are still deleted when
+  presented, but the response no longer reveals whether the token existed or why it failed.
 
 ### Changed
 
@@ -65,6 +68,10 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
   `django-rest-passwordreset-request-token`. Any active `ScopedRateThrottle` scope must have a matching
   `REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]` entry; otherwise the affected endpoint raises
   `ImproperlyConfigured` (HTTP 500).
+- **Breaking:** Token failure responses on validate/confirm are less specific. Expired tokens now
+  return the generic invalid-token 404 response instead of `"The token has expired"`. Confirming a
+  valid token whose user is inactive or otherwise ineligible now returns HTTP 404 instead of HTTP 200
+  and does not consume the token.
 - Removed Django 4.2 and 5.1 from the supported/tested matrix
 - Updated CI/CD pipelines to test currently supported Django/Python combinations
 - Updated PostgreSQL test service to version 14 (required by Django 5.2)

--- a/README.md
+++ b/README.md
@@ -59,10 +59,13 @@ The following endpoints are provided:
  * `POST ${API_URL}/` - request a reset password token by using the ``email`` parameter
  * `POST ${API_URL}/confirm/` - using a valid ``token``, the users password is set to the provided ``password``
  * `POST ${API_URL}/validate_token/` - will return a 200 if a given ``token`` is valid
- 
+
 where `${API_URL}/` is the url specified in your *urls.py* (e.g., `api/password_reset/` as in the example above)
 
- 
+Invalid, expired, or unusable tokens return the same generic HTTP 404 response on the
+``confirm`` and ``validate_token`` endpoints. Expired tokens are deleted when presented, but
+the response intentionally does not say whether the token was missing, expired, or unusable.
+
 ### Signals
 
 * ``reset_password_token_created(sender, instance, reset_password_token)`` Fired when a reset password token is generated

--- a/django_rest_passwordreset/serializers.py
+++ b/django_rest_passwordreset/serializers.py
@@ -16,6 +16,8 @@ __all__ = [
     'ResetTokenSerializer',
 ]
 
+INVALID_TOKEN_ERROR = _("The OTP password entered is not valid. Please check and try again.")
+
 
 class EmailSerializer(serializers.Serializer):
     email = serializers.EmailField()
@@ -33,7 +35,7 @@ class PasswordValidateMixin:
             reset_password_token = _get_object_or_404(models.ResetPasswordToken, key=token)
         except (TypeError, ValueError, ValidationError, Http404,
                 models.ResetPasswordToken.DoesNotExist):
-            raise Http404(_("The OTP password entered is not valid. Please check and try again."))
+            raise Http404(INVALID_TOKEN_ERROR)
 
         # check expiry date
         expiry_date = reset_password_token.created_at + timedelta(
@@ -42,7 +44,7 @@ class PasswordValidateMixin:
         if timezone.now() > expiry_date:
             # delete expired token
             reset_password_token.delete()
-            raise Http404(_("The token has expired"))
+            raise Http404(INVALID_TOKEN_ERROR)
         return data
 
 

--- a/django_rest_passwordreset/views.py
+++ b/django_rest_passwordreset/views.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password, get_password_validators
 from django.core.exceptions import ValidationError
+from django.http import Http404
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
@@ -14,7 +15,8 @@ from rest_framework.viewsets import GenericViewSet
 
 from django_rest_passwordreset.models import ResetPasswordToken, clear_expired, get_password_reset_token_expiry_time, \
     get_password_reset_lookup_field
-from django_rest_passwordreset.serializers import EmailSerializer, PasswordTokenSerializer, ResetTokenSerializer
+from django_rest_passwordreset.serializers import EmailSerializer, INVALID_TOKEN_ERROR, PasswordTokenSerializer, \
+    ResetTokenSerializer
 from django_rest_passwordreset.signals import reset_password_token_created, pre_password_reset, post_password_reset
 from django_rest_passwordreset.throttling import get_password_reset_request_token_throttle_classes
 
@@ -155,33 +157,35 @@ class ResetPasswordConfirm(GenericAPIView):
         # find token
         reset_password_token = ResetPasswordToken.objects.filter(key=token).first()
 
-        # change users password (if we got to this code it means that the user is_active)
-        if reset_password_token.user.eligible_for_reset():
-            pre_password_reset.send(
-                sender=self.__class__,
-                user=reset_password_token.user,
-                reset_password_token=reset_password_token,
-            )
-            try:
-                # validate the password against existing validators
-                validate_password(
-                    password,
-                    user=reset_password_token.user,
-                    password_validators=get_password_validators(settings.AUTH_PASSWORD_VALIDATORS)
-                )
-            except ValidationError as e:
-                # raise a validation error for the serializer
-                raise exceptions.ValidationError({
-                    'password': e.messages
-                })
+        if reset_password_token is None or not reset_password_token.user.eligible_for_reset():
+            raise Http404(INVALID_TOKEN_ERROR)
 
-            reset_password_token.user.set_password(password)
-            reset_password_token.user.save()
-            post_password_reset.send(
-                sender=self.__class__,
+        # change user's password after token and eligibility checks
+        pre_password_reset.send(
+            sender=self.__class__,
+            user=reset_password_token.user,
+            reset_password_token=reset_password_token,
+        )
+        try:
+            # validate the password against existing validators
+            validate_password(
+                password,
                 user=reset_password_token.user,
-                reset_password_token=reset_password_token,
+                password_validators=get_password_validators(settings.AUTH_PASSWORD_VALIDATORS)
             )
+        except ValidationError as e:
+            # raise a validation error for the serializer
+            raise exceptions.ValidationError({
+                'password': e.messages
+            })
+
+        reset_password_token.user.set_password(password)
+        reset_password_token.user.save()
+        post_password_reset.send(
+            sender=self.__class__,
+            user=reset_password_token.user,
+            reset_password_token=reset_password_token,
+        )
 
         # Delete all password reset tokens for this user
         ResetPasswordToken.objects.filter(user=reset_password_token.user).delete()

--- a/tests/test/test_auth_test_case.py
+++ b/tests/test/test_auth_test_case.py
@@ -489,3 +489,96 @@ class AuthTestCase(APITestCase, HelperMixin):
 
         # there should be one token
         self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
+
+
+class ResponseIndistinguishabilityTestCase(APITestCase, HelperMixin):
+    """ Tests reset-token responses that should not expose token state. """
+
+    def setUp(self):
+        self.setUpUrls()
+        self.user_active = User.objects.create_user("active_user", "active@mail.com", "secret_active")
+        self.user_inactive = User.objects.create_user("inactive_user", "inactive@mail.com", "secret_inactive")
+        self.user_inactive.is_active = False
+        self.user_inactive.save()
+
+    def _request_token(self):
+        response = self.rest_do_request_reset_token(email="active@mail.com")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return ResetPasswordToken.objects.get(user=self.user_active)
+
+    def _expire_token(self, token):
+        token.created_at = timezone.now() - timedelta(hours=get_password_reset_token_expiry_time() + 1)
+        token.save()
+
+    @patch('django_rest_passwordreset.signals.reset_password_token_created.send')
+    def test_validate_missing_and_expired_tokens_return_same_response(self, mock_reset_signal):
+        """ Tests validate returns the same response for missing and expired tokens """
+        response_missing = self.rest_do_validate_token("this-token-does-not-exist")
+        self.assertEqual(response_missing.status_code, status.HTTP_404_NOT_FOUND)
+
+        token = self._request_token()
+        self._expire_token(token)
+        response_expired = self.rest_do_validate_token(token.key)
+        self.assertEqual(response_expired.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(
+            response_missing.content,
+            response_expired.content,
+            msg="validate must return identical bodies for non-existent vs expired tokens",
+        )
+
+    @patch('django_rest_passwordreset.signals.reset_password_token_created.send')
+    def test_confirm_missing_and_expired_tokens_return_same_response(self, mock_reset_signal):
+        """ Tests confirm returns the same response for missing and expired tokens """
+        response_missing = self.rest_do_reset_password_with_token("this-token-does-not-exist", "NewStrongPassword1!")
+        self.assertEqual(response_missing.status_code, status.HTTP_404_NOT_FOUND)
+
+        token = self._request_token()
+        self._expire_token(token)
+        response_expired = self.rest_do_reset_password_with_token(token.key, "NewStrongPassword1!")
+        self.assertEqual(response_expired.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(
+            response_missing.content,
+            response_expired.content,
+            msg="confirm must return identical bodies for non-existent vs expired tokens",
+        )
+
+    def test_confirm_inactive_user_token_returns_404_without_deleting_token(self):
+        """ Tests confirm rejects tokens for inactive users without deleting them """
+        response_missing = self.rest_do_reset_password_with_token("this-token-does-not-exist", "NewStrongPassword1!")
+        self.assertEqual(response_missing.status_code, status.HTTP_404_NOT_FOUND)
+
+        token = ResetPasswordToken.objects.create(user=self.user_inactive)
+        self.assertEqual(ResetPasswordToken.objects.filter(pk=token.pk).count(), 1)
+
+        response = self.rest_do_reset_password_with_token(token.key, "NewStrongPassword1!")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.content, response_missing.content)
+
+        self.assertEqual(
+            ResetPasswordToken.objects.filter(pk=token.pk).count(),
+            1,
+            msg="confirm must not delete a token presented for an inactive user",
+        )
+
+    @patch('django_rest_passwordreset.signals.reset_password_token_created.send')
+    @override_settings(
+        AUTH_PASSWORD_VALIDATORS=[
+            {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator", "OPTIONS": {"min_length": 8}},
+        ]
+    )
+    def test_confirm_weak_password_returns_400_without_deleting_token(self, mock_reset_signal):
+        """ Tests weak password returns a password error and keeps the token """
+        token = self._request_token()
+
+        weak_response = self.rest_do_reset_password_with_token(token.key, "1")
+        self.assertEqual(weak_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertEqual(
+            ResetPasswordToken.objects.filter(pk=token.pk).count(),
+            1,
+            msg="confirm with a weak password must not consume the token",
+        )
+        body = json.loads(weak_response.content.decode())
+        self.assertIn("password", body)


### PR DESCRIPTION
Updates the password reset flow to improve security by making token validation and confirmation responses less specific, preventing attackers from distinguishing between invalid, expired, or ineligible tokens. It also adds comprehensive tests to ensure these behaviors and updates documentation to reflect the changes.

**Security and API behavior changes:**

* Both the `validate_token` and `confirm` endpoints now return the same generic HTTP 404 response for missing, malformed, expired, or ineligible-user tokens, instead of different messages for each case. Expired tokens are still deleted, but the response does not reveal the reason for failure.