### PR TITLE
Add DRF 3.17 support

### DIFF
--- a/.github/workflows/test-postgres.yml
+++ b/.github/workflows/test-postgres.yml
@@ -32,6 +32,7 @@ jobs:
           - "6.0"
         drf-version:
           - "3.16"
+          - "3.17"
         exclude:
           - python-version: "3.10"
             django-version: "6.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - "6.0"
         drf-version:
           - "3.16"
+          - "3.17"
         exclude:
           - python-version: "3.10"
             django-version: "6.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ PyPi: [https://pypi.org/project/django-rest-passwordreset/](https://pypi.org/pro
 - Added Django 5.2 LTS support
 - Added Django 6.0 support
 - Added Django Rest Framework 3.16 support
+- Added Django Rest Framework 3.17 support
 - Added `DJANGO_REST_PASSWORDRESET_THROTTLE_CLASSES` to replace the request-token endpoint throttle
   classes. The default remains `ResetPasswordRequestTokenThrottle`; setting it to an empty list
   delegates the request-token endpoint to DRF's global `DEFAULT_THROTTLE_CLASSES`.

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ django-rest-passwordreset Version | Django Versions     | Django Rest Framework 
 1.3 | 3.2, 4.0, 4.1 | 3.12, 3.13, 3.14 | 3.7 - 3.10
 1.4 | 3.2, 4.2, 5.0 | 3.13, 3.14 | 3.8 - 3.12
 1.5 | 4.2, 5.0, 5.1 | 3.15 | 3.9 - 3.13
-1.6 (current) | 5.2, 6.0 | 3.16 | 3.10 - 3.14*
+1.6 (current) | 5.2, 6.0 | 3.16, 3.17 | 3.10 - 3.14*
 
 \* Django 6.0 is tested on Python 3.12 - 3.14, while Django 5.2 is tested on Python 3.10 - 3.14.
 


### PR DESCRIPTION
Adds support for Django Rest Framework (DRF) version 3.17 across the codebase. The main changes update documentation and CI workflows to reflect and test against the new DRF version.